### PR TITLE
Add type tag to subnets

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This is a module which simplifies setting up a new VPC and getting it into a use
 - Creates the desired number of private subnets (with one NAT gateway and route table per subnet).
 - Creates an egress only internet gateway for IPv6 traffic outbound from the private subnets
 - Evenly splits the specified IPv4 CIDR block between public/private subnets.
+- Adds the tag `type` to each subnet with the value of either `public` or `private`.
 
 Note that, if `create_nat_gateways` is enabled, each private subnet has a route table which targets an individual NAT gateway when accessing
 the internet over IPv4, which means that all instances in a given private subnet will appear to have the same static IP from the outside.

--- a/main.tf
+++ b/main.tf
@@ -63,7 +63,7 @@ resource "aws_subnet" "public" {
   map_public_ip_on_launch         = "true"
   assign_ipv6_address_on_creation = "true"
 
-  tags = "${merge(var.tags, map("Name", "${var.name_prefix}-public-subnet-${count.index + 1}"))}"
+  tags = "${merge(var.tags, map("Name", "${var.name_prefix}-public-subnet-${count.index + 1}", "type", "public"))}"
 }
 
 resource "aws_route_table_association" "public" {
@@ -118,7 +118,7 @@ resource "aws_subnet" "private" {
   map_public_ip_on_launch         = "false"
   assign_ipv6_address_on_creation = "true"
 
-  tags = "${merge(var.tags, map("Name", "${var.name_prefix}-private-subnet-${count.index + 1}"))}"
+  tags = "${merge(var.tags, map("Name", "${var.name_prefix}-private-subnet-${count.index + 1}", "type", "private"))}"
 }
 
 resource "aws_route_table_association" "private" {


### PR DESCRIPTION
Will allows easy lookup public/private subnets from terraform, for example:
```
data "aws_vpc" "my_vpc" {
  tags {
    Name = "my_vpc"
  }
}

data "aws_subnet_ids" "private" {
  vpc_id = "${data.aws_vpc.my_vpc.id}"
  tags {
    type = "private"
  }
}
```