### PR TITLE
Make subnets configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 
 This is a module which simplifies setting up a new VPC and getting it into a useful state:
 
-- Creates one public subnet per availability zone (with a shared route table and internet gateway).
+- Creates one public subnet per availability zone (with a shared route table and internet gateway) by default.
 - Creates the desired number of private subnets (with one NAT gateway and route table per subnet).
-- Creates an egress only internet gateway for IPv6 traffic outbound from the private subnets
-- Evenly splits the specified IPv4 CIDR block between public/private subnets.
+- Enables IPv6 for the VPC and allocates a /64 block for each of the public and private subnets.
+- Creates an egress only internet gateway for IPv6 traffic outbound from the private subnets.
 - Adds the tag `type` to each subnet with the value of either `public` or `private`.
 
 Note that, if `create_nat_gateways` is enabled, each private subnet has a route table which targets an individual NAT gateway when accessing

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -8,17 +8,24 @@ provider "aws" {
 }
 
 module "vpc" {
-  source                 = "../../"
-  name_prefix            = var.name_prefix
-  cidr_block             = "10.100.0.0/16"
-  create_nat_gateways    = false
-  enable_dns_hostnames   = true
-  create_private_subnets = true
+  source      = "../../"
+  name_prefix = var.name_prefix
+  cidr_block  = "10.100.0.0/16"
 
+  availability_zones = [
+    "eu-west-1a",
+    "eu-west-1b",
+    "eu-west-1c",
+  ]
+
+  create_private_subnets = true
   private_subnet_cidrs = [
     "10.100.48.0/20",
     "10.100.64.0/20",
   ]
+
+  create_nat_gateways  = true
+  enable_dns_hostnames = true
 
   tags = {
     terraform   = "True"

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -8,12 +8,17 @@ provider "aws" {
 }
 
 module "vpc" {
-  source               = "../../"
-  name_prefix          = var.name_prefix
-  cidr_block           = "10.100.0.0/16"
-  create_nat_gateways  = false
-  enable_dns_hostnames = true
-  private_subnet_count = 2
+  source                 = "../../"
+  name_prefix            = var.name_prefix
+  cidr_block             = "10.100.0.0/16"
+  create_nat_gateways    = false
+  enable_dns_hostnames   = true
+  create_private_subnets = true
+
+  private_subnet_cidrs = [
+    "10.100.48.0/20",
+    "10.100.64.0/20",
+  ]
 
   tags = {
     terraform   = "True"

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -18,7 +18,12 @@ module "vpc" {
     "eu-west-1c",
   ]
 
-  create_private_subnets = true
+  public_subnet_cidrs = [
+    "10.100.0.0/20",
+    "10.100.16.0/20",
+    "10.100.32.0/20",
+  ]
+
   private_subnet_cidrs = [
     "10.100.48.0/20",
     "10.100.64.0/20",

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -11,7 +11,7 @@ module "vpc" {
   source               = "../../"
   name_prefix          = var.name_prefix
   cidr_block           = "10.100.0.0/16"
-  create_nat_gateways  = true
+  create_nat_gateways  = false
   enable_dns_hostnames = true
   private_subnet_count = 2
 

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -1,6 +1,6 @@
 variable "name_prefix" {
   type    = string
-  default = "vpc-basic-example"
+  default = "vpc-complete-example"
 }
 
 variable "region" {

--- a/main.tf
+++ b/main.tf
@@ -5,8 +5,8 @@ data "aws_availability_zones" "main" {}
 
 locals {
   azs               = length(var.availability_zones) > 0 ? var.availability_zones : data.aws_availability_zones.main.names
-  public_cidrs      = length(var.public_subnet_cidrs) > 0 ? var.public_subnet_cidrs : [for i, _ in local.azs : cidrsubnet(var.cidr_block, 4, i) if i <= length(local.azs)]
-  private_cidrs     = length(var.private_subnet_cidrs) > 0 ? var.private_subnet_cidrs : [for i, _ in local.azs : cidrsubnet(var.cidr_block, 4, i + length(local.public_cidrs)) if i <= length(local.azs)]
+  public_cidrs      = coalescelist(var.public_subnet_cidrs, [for i, _ in local.azs : cidrsubnet(var.cidr_block, 4, i)])
+  private_cidrs     = coalescelist(var.private_subnet_cidrs, [for i, _ in local.azs : cidrsubnet(var.cidr_block, 4, i)])
   public_subnets    = var.create_public_subnets ? local.public_cidrs : []
   private_subnets   = var.create_private_subnets ? local.private_cidrs : []
   nat_gateway_count = var.create_nat_gateways && var.create_public_subnets ? length(local.private_subnets) : 0

--- a/main.tf
+++ b/main.tf
@@ -4,16 +4,9 @@
 data "aws_availability_zones" "main" {}
 
 locals {
-  azs = length(var.availability_zones) > 0 ? var.availability_zones : data.aws_availability_zones.main.names
-
-  public_cidrs = length(var.public_subnet_cidrs) > 0 ? var.public_subnet_cidrs : [
-    for i, _ in local.azs : cidrsubnet(var.cidr_block, 4, i) if i <= length(local.azs)
-  ]
-
-  private_cidrs = length(var.private_subnet_cidrs) > 0 ? var.private_subnet_cidrs : [
-    for i, _ in local.azs : cidrsubnet(var.cidr_block, 4, i + length(local.public_cidrs)) if i <= length(local.azs)
-  ]
-
+  azs               = length(var.availability_zones) > 0 ? var.availability_zones : data.aws_availability_zones.main.names
+  public_cidrs      = length(var.public_subnet_cidrs) > 0 ? var.public_subnet_cidrs : [for i, _ in local.azs : cidrsubnet(var.cidr_block, 4, i) if i <= length(local.azs)]
+  private_cidrs     = length(var.private_subnet_cidrs) > 0 ? var.private_subnet_cidrs : [for i, _ in local.azs : cidrsubnet(var.cidr_block, 4, i + length(local.public_cidrs)) if i <= length(local.azs)]
   public_subnets    = var.create_public_subnets ? local.public_cidrs : []
   private_subnets   = var.create_private_subnets ? local.private_cidrs : []
   nat_gateway_count = var.create_nat_gateways && var.create_public_subnets ? length(local.private_subnets) : 0

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@ data "aws_availability_zones" "main" {}
 
 locals {
   azs               = length(var.availability_zones) > 0 ? var.availability_zones : data.aws_availability_zones.main.names
-  nat_gateway_count = var.create_nat_gateways ? min(length(azs), length(var.public_subnet_cidrs)) : 0
+  nat_gateway_count = var.create_nat_gateways ? min(length(local.azs), length(var.public_subnet_cidrs), length(var.private_subnet_cidrs)) : 0
 }
 
 resource "aws_vpc" "main" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,22 +8,22 @@ output "vpc_id" {
 
 output "public_subnet_ids" {
   description = "The ID of the public subnets."
-  value       = aws_subnet.public.*.id
+  value       = aws_subnet.public[*].id
 }
 
 output "private_subnet_ids" {
   description = "The ID of the private subnets."
-  value       = aws_subnet.private.*.id
+  value       = aws_subnet.private[*].id
 }
 
 output "public_subnets_route_table_id" {
   description = "The ID of the routing table for the public subnets."
-  value       = aws_route_table.public.id
+  value       = aws_route_table.public[*].id
 }
 
 output "private_subnets_route_table_ids" {
   description = "The IDs of the routing tables for the private subnets."
-  value       = aws_route_table.private.*.id
+  value       = aws_route_table.private[*].id
 }
 
 output "main_route_table_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -21,7 +21,7 @@ variable "availability_zones" {
 variable "public_subnet_cidrs" {
   description = "A list of CIDR blocks to use for the public subnets."
   type        = list(string)
-  default     = ["10.0.0.0/20", "10.0.16.0/20", "10.0.32.0/20"]
+  default     = null
 }
 
 variable "private_subnet_cidrs" {

--- a/variables.tf
+++ b/variables.tf
@@ -13,13 +13,13 @@ variable "cidr_block" {
 }
 
 variable "availability_zones" {
-  description = "The availability zones to use for the subnets."
+  description = "The availability zones to use for subnets and resources in the VPC. By default, all AZs in the region will be used."
   type        = list(string)
   default     = []
 }
 
 variable "public_subnet_cidrs" {
-  description = "A list of CIDR blocks to use for the public subnets."
+  description = "A list of CIDR blocks to use for the public subnets. When null, creates a single /20-prefixed subnet per AZ."
   type        = list(string)
   default     = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -18,22 +18,10 @@ variable "availability_zones" {
   default     = []
 }
 
-variable "create_public_subnets" {
-  description = "Flag to create public subnets."
-  type        = bool
-  default     = true
-}
-
-variable "create_private_subnets" {
-  description = "Flag to create private subnets."
-  type        = bool
-  default     = false
-}
-
 variable "public_subnet_cidrs" {
   description = "A list of CIDR blocks to use for the public subnets."
   type        = list(string)
-  default     = []
+  default     = ["10.0.0.0/20", "10.0.16.0/20", "10.0.32.0/20"]
 }
 
 variable "private_subnet_cidrs" {
@@ -43,7 +31,7 @@ variable "private_subnet_cidrs" {
 }
 
 variable "create_nat_gateways" {
-  description = "If this is set to false NAT gateways (which cost $) will not be created and the private subnets will only route trafffic to the internet via the egress only gateway(no cost) - Egress only gateways only work for IPv6)"
+  description = "Optionally create NAT gateways (which cost $) to provide internet connectivity to the private subnets."
   type        = bool
   default     = true
 }

--- a/variables.tf
+++ b/variables.tf
@@ -12,6 +12,36 @@ variable "cidr_block" {
   default     = "10.0.0.0/16"
 }
 
+variable "availability_zones" {
+  description = "The availability zones to use for the subnets."
+  type        = list(string)
+  default     = []
+}
+
+variable "create_public_subnets" {
+  description = "Flag to create public subnets."
+  type        = bool
+  default     = true
+}
+
+variable "create_private_subnets" {
+  description = "Flag to create private subnets."
+  type        = bool
+  default     = false
+}
+
+variable "public_subnet_cidrs" {
+  description = "A list of CIDR blocks to use for the public subnets."
+  type        = list(string)
+  default     = []
+}
+
+variable "private_subnet_cidrs" {
+  description = "A list of CIDR blocks to use for the private subnets."
+  type        = list(string)
+  default     = []
+}
+
 variable "create_nat_gateways" {
   description = "If this is set to false NAT gateways (which cost $) will not be created and the private subnets will only route trafffic to the internet via the egress only gateway(no cost) - Egress only gateways only work for IPv6)"
   type        = bool
@@ -22,12 +52,6 @@ variable "enable_dns_hostnames" {
   description = "A boolean flag to enable/disable DNS hostnames in the VPC."
   type        = bool
   default     = false
-}
-
-variable "private_subnet_count" {
-  description = "Number of private subnets to provision (will not exceed the number of AZ's in the region)."
-  type        = number
-  default     = 0
 }
 
 variable "tags" {


### PR DESCRIPTION
The goal of this PR is to support small CIDR blocks better by allowing the following:
1. Creating VPC's with no public subnets.
   - Since we are making public subnets optional, we need to make Internet/NAT gatways optional.
2. More flexibility with regards to the subnets CIDRs to use (i.e. not using ~50% of the IPs for public subnets).

The latest commit of the PR does not produce a diff when running `terraform apply` against an infrastructure that was deployed by the examples currently on `master`. Users will experience a "breaking change" in that they will now have to specify `private_subnet_cidrs` instead of `private_subnet_count` - this is to support more advanced uses like goal number 2.

The interaction between `availability_zones`, `create_private_subnets` and `private_subnet_cidrs` (same for public subnets`) is as follows:
- `availability_zones` defaults to _all_ AZs. If you specify e.g. `["eu-west-1a", and "eu-west-1b"]` it will only use those AZs for the subnets that are created (using `element()` function in terraform so we can support an arbitrary number of subnets even so).
- `create_private_subnets` overrides everything, if it's set to `false` (the default) then no private subnets will be created - even if the user specified `private_subnet_cidrs`.
- `private_subnet_cidrs` is optional and is what allows us to specify both the number of private subnets to create, and their CIDR blocks, so we can have subnets of varying sizes if we want. When not specified, the module will default to creating 1x private subnet per AZ and using `cidr_block` with 4 newbits as the... CIDR block.

Perhaps the interactions here are a bit complex, so I'm open to suggestions 😅 