### PR TITLE
improve tagging

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -90,7 +90,7 @@ resource "aws_subnet" "public" {
     var.tags,
     {
       "Name" = "${var.name_prefix}-public-subnet-${count.index + 1}"
-      "type" = "public"
+      "Tier" = "Public"
     },
   )
 }
@@ -177,7 +177,7 @@ resource "aws_subnet" "private" {
     var.tags,
     {
       "Name" = "${var.name_prefix}-private-subnet-${count.index + 1}"
-      "type" = "private"
+      "Tier" = "Private"
     },
   )
 }


### PR DESCRIPTION
The changes here to improve the tag name

- use capital letter
- change the tag name from type to Tier

This helpful when using the data source to get private subnets ids 
```
data "aws_subnet_ids" "private" {
  vpc_id = var.vpc_id

  tags = {
    Tier = "Private"
  }
}

```
Using `Tier` is just more helpful than `type` because Terraform documentation use `Tier`  then no need to look at the module code to figure out the tag name. 

Related PR: https://github.com/telia-oss/terraform-aws-loadbalancer/pull/13