### PR TITLE
Added output of default_network_acl_id

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -45,3 +45,8 @@ output "default_security_group_id" {
   description = "The id of the VPC default security group"
   value       = aws_vpc.main.default_security_group_id
 }
+
+output "default_network_acl_id" {
+  description = "The ID of the network ACL created by default on VPC creation"
+  value       = aws_vpc.main.default_network_acl_id
+}


### PR DESCRIPTION
This is needed to modify the  `aws_default_network_acl` resource.