### PR TITLE
IPv6 renumbering fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,7 @@ This is a module which simplifies setting up a new VPC and getting it into a use
 
 Note that, if `create_nat_gateways` is enabled, each private subnet has a route table which targets an individual NAT gateway when accessing
 the internet over IPv4, which means that all instances in a given private subnet will appear to have the same static IP from the outside.
+
+Note: if you already have a VPC setup with private subnets, and later add public subnets, your private subnet needs to be recreated due to how this module originally assigned IPv6 addresses.
+This can be avoided by setting the variables `ipv6_private_subnet_netnum_offset = 0` & `ipv6_public_subnet_netnum_offset = 128` which will force private subnets to still be allocated from 0, and public subnets from an offset.
+The maximum value of subnets in a IPv6 CIDR block is 255, we get a /56 from AWS and we divide them into /64 which gives us 8 bits for subnets. Hence 128 will allow 128 private subnets, and 128 public ones.

--- a/main.tf
+++ b/main.tf
@@ -83,7 +83,7 @@ resource "aws_subnet" "public" {
   count                           = length(var.public_subnet_cidrs)
   vpc_id                          = aws_vpc.main.id
   cidr_block                      = var.public_subnet_cidrs[count.index]
-  ipv6_cidr_block                 = cidrsubnet(aws_vpc.main.ipv6_cidr_block, 8, count.index)
+  ipv6_cidr_block                 = cidrsubnet(aws_vpc.main.ipv6_cidr_block, 8, var.ipv6_public_subnet_netnum_offset + count.index)
   availability_zone               = element(local.azs, count.index)
   map_public_ip_on_launch         = true
   assign_ipv6_address_on_creation = true
@@ -170,7 +170,7 @@ resource "aws_subnet" "private" {
   count                           = length(var.private_subnet_cidrs)
   vpc_id                          = aws_vpc.main.id
   cidr_block                      = var.private_subnet_cidrs[count.index]
-  ipv6_cidr_block                 = cidrsubnet(aws_vpc.main.ipv6_cidr_block, 8, count.index + length(var.public_subnet_cidrs))
+  ipv6_cidr_block                 = cidrsubnet(aws_vpc.main.ipv6_cidr_block, 8, count.index + (var.ipv6_private_subnet_netnum_offset == -1 ? length(var.public_subnet_cidrs) : var.ipv6_private_subnet_netnum_offset))
   availability_zone               = element(local.azs, count.index)
   map_public_ip_on_launch         = false
   assign_ipv6_address_on_creation = true

--- a/main.tf
+++ b/main.tf
@@ -194,10 +194,12 @@ resource "aws_vpc_endpoint" "s3" {
   service_name    = "com.amazonaws.${data.aws_region.current.name}.s3"
   vpc_id          = aws_vpc.main.id
   route_table_ids = compact(concat(aws_route_table.private.*.id, aws_route_table.public.*.id))
+  policy          = var.s3_endpoint_policy
 }
 
 resource "aws_vpc_endpoint" "dynamodb" {
   service_name    = "com.amazonaws.${data.aws_region.current.name}.dynamodb"
   vpc_id          = aws_vpc.main.id
   route_table_ids = compact(concat(aws_route_table.private.*.id, aws_route_table.public.*.id))
+  policy          = var.dynamodb_endpoint_policy
 }

--- a/variables.tf
+++ b/variables.tf
@@ -29,6 +29,18 @@ variable "private_subnet_cidrs" {
   default     = []
 }
 
+variable "ipv6_public_subnet_netnum_offset" {
+  description = "By default public IPv6 subnets is allocated from start of VPC IPv6 CIDR block. This can be used to force an offset, i.e. if adding public subnets when private ones already exists (which would be at beginning of block)."
+  type        = number
+  default     = 0
+}
+
+variable "ipv6_private_subnet_netnum_offset" {
+  description = "By default private IPv6 subnet is allocated directly after last public subnet. This can be used to force an offset."
+  type        = number
+  default     = -1
+}
+
 variable "create_nat_gateways" {
   description = "Optionally create NAT gateways (which cost $) to provide internet connectivity to the private subnets."
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -59,3 +59,12 @@ variable "tags" {
   default     = {}
 }
 
+variable "s3_endpoint_policy" {
+  description = "Policy document to attach to S3 Gateway Endpoint. Defaults to blank."
+  default     = null
+}
+
+variable "dynamodb_endpoint_policy" {
+  description = "Policy document to attach to DynamoDb Gateway Endpoint. Defaults to blank."
+  default     = null
+}


### PR DESCRIPTION
If this module have been used with private subnets only, adding public subnets to the configuration will make it attempt to renumber IPv6 cidrs of the private subnets (since private netnum = length(public)+count). 
This fails to apply:

```
module.aux_vpc.aws_subnet.public[0]: Creating...
module.aux_vpc.aws_subnet.public[1]: Creating...
module.aux_vpc.aws_subnet.private[1]: Modifying... [id=subnet-023895aa8317d6ba1]
module.aux_vpc.aws_subnet.private[0]: Modifying... [id=subnet-0fb608f48ee0ff064]

Error: error creating subnet: InvalidSubnet.Conflict: The IPv6 CIDR '2a05:xxx:1500::/64' conflicts with another subnet
	status code: 400, request id: e7fb0c1d-bb8b-496c-9e92-c01a4de6870b

  on .terraform/modules/aux_vpc/main.tf line 80, in resource "aws_subnet" "public":
  80: resource "aws_subnet" "public" {



Error: error creating subnet: InvalidSubnet.Conflict: The IPv6 CIDR '2a05:xxx:1501::/64' conflicts with another subnet
	status code: 400, request id: 7167599f-bda7-4823-a32b-a3b712e84859

  on .terraform/modules/aux_vpc/main.tf line 80, in resource "aws_subnet" "public":
  80: resource "aws_subnet" "public" {



Error: InvalidCidrBlock.InUse: The subnet IPv6 CIDR block with association ID subnet-cidr-assoc-035f8fa33f9798fac may not be disassociated, because its subnet has assign-ipv6-address-on-creation set to true.
	status code: 400, request id: 5ec27cc1-8638-4169-83bf-c878b7e1cdae

  on .terraform/modules/aux_vpc/main.tf line 167, in resource "aws_subnet" "private":
 167: resource "aws_subnet" "private" {



Error: InvalidCidrBlock.InUse: The subnet IPv6 CIDR block with association ID subnet-cidr-assoc-03e8306827f6c67bd may not be disassociated, because its subnet has assign-ipv6-address-on-creation set to true.
	status code: 400, request id: 34a451f0-3dab-49bd-ba75-bd71dc2d3e7e

  on .terraform/modules/aux_vpc/main.tf line 167, in resource "aws_subnet" "private":
 167: resource "aws_subnet" "private" {
 ```

This patch allows us to use apply an alternative numbering scheme and keep the existing private subnets as-is.
An alternative solution could be to just expose a boolean `use_alternative_ipv6_numbering` or something, and use a static offset of 128.. but prefer to keep it flexible.

Also, includes patch to allow setting JSON policies on the new endpoint objects.

Greetings from Telia TV Media!