### PR TITLE
Make both Internet gateway and egress-only Internet gateway optional

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -9,8 +9,8 @@ locals {
   azs               = length(var.availability_zones) > 0 ? var.availability_zones : data.aws_availability_zones.main.names
   nat_gateway_count = var.create_nat_gateways ? min(length(local.azs), length(var.public_subnet_cidrs), length(var.private_subnet_cidrs)) : 0
 
-  internet_gateway_count             = (var.create_internet_gateway && length(var.public_subnet_cidrs)) > 0 ? 1 : 0
-  egress_only_internet_gateway_count = (var.create_egress_only_internet_gateway && length(var.public_subnet_cidrs)) > 0 ? 1 : 0
+  internet_gateway_count             = (var.create_internet_gateway && length(var.public_subnet_cidrs) > 0) ? 1 : 0
+  egress_only_internet_gateway_count = (var.create_egress_only_internet_gateway && length(var.public_subnet_cidrs) > 0) ? 1 : 0
 }
 
 resource "aws_vpc" "main" {

--- a/variables.tf
+++ b/variables.tf
@@ -53,6 +53,18 @@ variable "create_nat_gateways" {
   default     = true
 }
 
+variable "create_internet_gateway" {
+  description = "Optionaly create an Internet Gateway resource"
+  type        = bool
+  default     = true
+}
+
+variable "create_egress_only_internet_gateway" {
+  description = "Optionaly create an Egress Only Internet Gateway resource"
+  type        = bool
+  default     = true
+}
+
 variable "enable_dns_hostnames" {
   description = "A boolean flag to enable/disable DNS hostnames in the VPC."
   type        = bool


### PR DESCRIPTION
This change should be backwards compatible and give zero change to existing configurations. I have tested that in a configuration myself.