### PR TITLE
Do not create "ipv6-private" aws_route when create_egress_only_internet_gateway = false

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -163,7 +163,7 @@ resource "aws_route" "ipv6-private" {
     aws_egress_only_internet_gateway.outbound,
     aws_route_table.private,
   ]
-  count                       = length(var.private_subnet_cidrs) > 0 ? length(var.private_subnet_cidrs) : 0
+  count                       = length(var.private_subnet_cidrs) > 0 && local.egress_only_internet_gateway_count > 0 ? length(var.private_subnet_cidrs) : 0
   route_table_id              = aws_route_table.private[count.index].id
   egress_only_gateway_id      = aws_egress_only_internet_gateway.outbound[0].id
   destination_ipv6_cidr_block = "::/0"


### PR DESCRIPTION
"ipv6-private" aws_route resource is in creation even if there is no aws_egress_only_internet_gateway.

This causes error:

╷
│ Error: Invalid index
│
│   on terraform-aws-vpc/main.tf line 168, in resource "aws_route" "ipv6-private":
│  168:   egress_only_gateway_id      = aws_egress_only_internet_gateway.outbound[0].id
│     ├────────────────
│     │ aws_egress_only_internet_gateway.outbound is empty tuple
│
│ The given key does not identify an element in this collection value: the collection has no elements.
